### PR TITLE
preserve the order the option were defined in the generated doc

### DIFF
--- a/R/options_roxygen.R
+++ b/R/options_roxygen.R
@@ -42,7 +42,7 @@ as_roxygen_docs <- function(
     "@seealso options getOption Sys.setenv Sys.getenv",
     "@section Options:",
     "\\describe{",
-    vapply(setdiff(names(optenv), CONST_OPTIONS_META), function(n) {
+    vapply(setdiff(names(details), CONST_OPTIONS_META), function(n) {
       sprintf(
         "\\item{%s}{\\describe{%s}}\n", n,
         paste0(

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -31,3 +31,22 @@ test_that("options objects pretty print", {
   expect_match(out, " default")
   Sys.unsetenv("OPT_A")
 })
+
+test_that("options objects prints options in definition order", {
+  e <- new.env(parent = baseenv())
+
+  expect_silent(with(e, options::define_option(
+    "B",
+    default = 2,
+    envvar_name = "OPT_B"
+  )))
+
+  expect_silent(with(e, options::define_option(
+    "A",
+    default = 1,
+    envvar_name = "OPT_A"
+  )))
+
+  expect_silent(out <- paste0(capture.output(e$.options), collapse = "\n"))
+  expect_match(out, "OPT_B.*OPT_A")
+})

--- a/tests/testthat/test-roxygen2.R
+++ b/tests/testthat/test-roxygen2.R
@@ -15,6 +15,15 @@ test_that("roxygen2-style block is generated from options env object", {
   expect_match(block, "\\{envvar: \\}\\{OPT_A")
 })
 
+test_that("roxygen2 options documentation is in definition order", {
+  e <- test_env()
+  expect_silent(with(e, options::define_option("B")))
+  expect_silent(with(e, options::define_option("A")))
+
+  expect_silent(block <- paste0(as_roxygen_docs(env = e), collapse = "\n"))
+  expect_match(block, "\\\\item\\{B\\}.*\\\\item\\{A\\}")
+})
+
 test_that("roxygen2-style params block is generated from as_params", {
   e <- test_env()
 


### PR DESCRIPTION
This is an attempt. Don't know if the same behavior happens for other users.

names(optenv) does not seems to return the names in the same order as they were defined with successive define_option. I wonder if using names(details) can work instead, wonder why it wasn't used in the first place?

Anyway.